### PR TITLE
Fix NaN check for default waitPeriod

### DIFF
--- a/queue-consumer/index.js
+++ b/queue-consumer/index.js
@@ -81,7 +81,7 @@ async function processMessage(message) {
   console.log(`${message.MessageId} - Received`);
 
   var waitPeriod = Number(message.Body);
-  if (waitPeriod === NaN) {
+  if (Number.isNaN(waitPeriod)) {
     waitPeriod = 1000;
   }
 


### PR DESCRIPTION
*Description of changes:*
I noticed that a `NaN` check doesn't work since `NaN === NaN` returns `false`. `setTimeout` with `NaN` delay still runs, but this will fix it to use the default `waitPeriod`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
